### PR TITLE
Improve mobile responsiveness across UI

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -40,23 +40,23 @@ export default function Home() {
   }
 
   return (
-    <div className="container mx-auto px-4 py-8">
-      <header className="text-center mb-12">
-        <div className="flex items-center justify-center gap-3 mb-4">
-          <Camera className="w-8 h-8 text-blue-600" />
-          <h1 className="text-4xl font-bold text-gray-800">Photo Cleaner</h1>
+    <div className="container mx-auto max-w-6xl px-4 py-6 sm:py-8">
+      <header className="mb-8 text-center sm:mb-12">
+        <div className="mb-4 flex flex-col items-center justify-center gap-2 sm:flex-row sm:gap-3">
+          <Camera className="h-8 w-8 text-blue-600" />
+          <h1 className="text-3xl font-bold text-gray-800 sm:text-4xl">Photo Cleaner</h1>
         </div>
-        <p className="text-lg text-gray-600 max-w-2xl mx-auto">
+        <p className="mx-auto max-w-2xl text-base text-gray-600 sm:text-lg">
           Clean up your photo library with AI-powered duplicate detection and smart organization
         </p>
       </header>
 
-      <nav className="flex justify-center gap-4 mb-8">
+      <nav className="mb-8 flex w-full max-w-3xl flex-wrap items-stretch justify-center gap-3 sm:gap-4">
         <button
           onClick={() => setCurrentView('upload')}
-          className={`flex items-center gap-2 px-6 py-3 rounded-lg transition-colors ${
-            currentView === 'upload' 
-              ? 'bg-blue-600 text-white' 
+          className={`flex w-full items-center justify-center gap-2 rounded-lg px-4 py-2.5 text-sm font-medium transition-colors sm:w-auto sm:px-6 sm:py-3 ${
+            currentView === 'upload'
+              ? 'bg-blue-600 text-white'
               : 'bg-white text-gray-700 hover:bg-gray-50'
           }`}
         >
@@ -65,9 +65,9 @@ export default function Home() {
         </button>
         <button
           onClick={() => setCurrentView('grid')}
-          className={`flex items-center gap-2 px-6 py-3 rounded-lg transition-colors ${
-            currentView === 'grid' 
-              ? 'bg-blue-600 text-white' 
+          className={`flex w-full items-center justify-center gap-2 rounded-lg px-4 py-2.5 text-sm font-medium transition-colors sm:w-auto sm:px-6 sm:py-3 ${
+            currentView === 'grid'
+              ? 'bg-blue-600 text-white'
               : 'bg-white text-gray-700 hover:bg-gray-50'
           }`}
           disabled={photos.length === 0}
@@ -77,9 +77,9 @@ export default function Home() {
         </button>
         <button
           onClick={() => setCurrentView('swipe')}
-          className={`flex items-center gap-2 px-6 py-3 rounded-lg transition-colors ${
-            currentView === 'swipe' 
-              ? 'bg-blue-600 text-white' 
+          className={`flex w-full items-center justify-center gap-2 rounded-lg px-4 py-2.5 text-sm font-medium transition-colors sm:w-auto sm:px-6 sm:py-3 ${
+            currentView === 'swipe'
+              ? 'bg-blue-600 text-white'
               : 'bg-white text-gray-700 hover:bg-gray-50'
           }`}
           disabled={photos.length === 0}
@@ -89,9 +89,9 @@ export default function Home() {
         </button>
         <button
           onClick={() => setCurrentView('stats')}
-          className={`flex items-center gap-2 px-6 py-3 rounded-lg transition-colors ${
-            currentView === 'stats' 
-              ? 'bg-blue-600 text-white' 
+          className={`flex w-full items-center justify-center gap-2 rounded-lg px-4 py-2.5 text-sm font-medium transition-colors sm:w-auto sm:px-6 sm:py-3 ${
+            currentView === 'stats'
+              ? 'bg-blue-600 text-white'
               : 'bg-white text-gray-700 hover:bg-gray-50'
           }`}
         >
@@ -100,7 +100,7 @@ export default function Home() {
         </button>
       </nav>
 
-      <div className="bg-white rounded-xl shadow-lg p-6">
+      <div className="rounded-xl bg-white p-4 shadow-lg sm:p-6">
         <ClientOnly>
           {isAnalyzing && (
             <div className="mb-6 bg-blue-50 p-4 rounded-lg">

--- a/src/components/PhotoComparison.tsx
+++ b/src/components/PhotoComparison.tsx
@@ -48,10 +48,10 @@ export default function PhotoComparison({ photos, onClose, onPhotoDeleted }: Pho
   }
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-90 z-50 flex items-center justify-center p-4">
-      <div className="bg-white rounded-xl max-w-6xl w-full max-h-[90vh] overflow-hidden">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-90 p-4">
+      <div className="flex w-full max-w-6xl flex-col overflow-hidden rounded-xl bg-white shadow-xl max-h-[90vh]">
         {/* Header */}
-        <div className="flex items-center justify-between p-4 border-b">
+        <div className="flex flex-wrap items-center justify-between gap-3 border-b p-4">
           <div className="flex items-center gap-3">
             <h2 className="text-xl font-bold text-gray-900">Photo Comparison</h2>
             <span className="text-sm text-gray-600">
@@ -60,15 +60,15 @@ export default function PhotoComparison({ photos, onClose, onPhotoDeleted }: Pho
           </div>
           <button
             onClick={onClose}
-            className="w-8 h-8 bg-gray-100 rounded-full flex items-center justify-center hover:bg-gray-200 transition-colors"
+            className="flex h-8 w-8 items-center justify-center rounded-full bg-gray-100 transition-colors hover:bg-gray-200"
           >
             <X className="w-5 h-5" />
           </button>
         </div>
 
         {/* Main comparison area */}
-        <div className="p-6">
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <div className="flex-1 overflow-y-auto p-4 sm:p-6">
+          <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
             {/* Current photo */}
             <div className="space-y-4">
               <div className="relative aspect-square bg-gray-100 rounded-lg overflow-hidden">
@@ -110,18 +110,18 @@ export default function PhotoComparison({ photos, onClose, onPhotoDeleted }: Pho
                   )}
                 </div>
               </div>
-              
-              <div className="flex gap-2">
+
+              <div className="flex flex-col gap-2 sm:flex-row">
                 <button
                   onClick={() => handleDelete(currentPhoto)}
-                  className="flex-1 flex items-center justify-center gap-2 px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors"
+                  className="flex w-full items-center justify-center gap-2 rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-700 sm:flex-1"
                 >
                   <Trash2 className="w-4 h-4" />
                   Delete
                 </button>
                 <button
                   onClick={() => setSelectedPhoto(currentPhoto)}
-                  className="flex-1 flex items-center justify-center gap-2 px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors"
+                  className="flex w-full items-center justify-center gap-2 rounded-lg bg-green-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-green-700 sm:flex-1"
                 >
                   <Heart className="w-4 h-4" />
                   Keep
@@ -171,18 +171,18 @@ export default function PhotoComparison({ photos, onClose, onPhotoDeleted }: Pho
                     )}
                   </div>
                 </div>
-                
-                <div className="flex gap-2">
+
+                <div className="flex flex-col gap-2 sm:flex-row">
                   <button
                     onClick={() => handleDelete(nextPhoto)}
-                    className="flex-1 flex items-center justify-center gap-2 px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors"
+                    className="flex w-full items-center justify-center gap-2 rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-700 sm:flex-1"
                   >
                     <Trash2 className="w-4 h-4" />
                     Delete
                   </button>
                   <button
                     onClick={() => setSelectedPhoto(nextPhoto)}
-                    className="flex-1 flex items-center justify-center gap-2 px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors"
+                    className="flex w-full items-center justify-center gap-2 rounded-lg bg-green-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-green-700 sm:flex-1"
                   >
                     <Heart className="w-4 h-4" />
                     Keep
@@ -193,25 +193,25 @@ export default function PhotoComparison({ photos, onClose, onPhotoDeleted }: Pho
           </div>
 
           {/* Navigation */}
-          <div className="flex items-center justify-between mt-6">
+          <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <button
               onClick={handlePrevious}
               disabled={currentIndex === 0}
-              className="flex items-center gap-2 px-4 py-2 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              className="flex w-full items-center justify-center gap-2 rounded-lg bg-gray-100 px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-200 disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto"
             >
               <ArrowLeft className="w-4 h-4" />
               Previous
             </button>
-            
-            <div className="flex items-center gap-2 text-sm text-gray-600">
+
+            <div className="flex items-center justify-center gap-2 text-center text-sm text-gray-600">
               <Info className="w-4 h-4" />
               <span>Compare photos side-by-side to choose which to keep</span>
             </div>
-            
+
             <button
               onClick={handleNext}
               disabled={currentIndex >= photos.length - 1}
-              className="flex items-center gap-2 px-4 py-2 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              className="flex w-full items-center justify-center gap-2 rounded-lg bg-gray-100 px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-200 disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto"
             >
               Next
               <ArrowRight className="w-4 h-4" />

--- a/src/components/PhotoGrid.tsx
+++ b/src/components/PhotoGrid.tsx
@@ -69,15 +69,15 @@ export default function PhotoGrid({ photos, onPhotoDeleted }: PhotoGridProps) {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-4">
-          <h2 className="text-2xl font-bold text-gray-900">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between lg:items-center lg:gap-6">
+          <h2 className="text-2xl font-bold text-gray-900 sm:text-3xl">
             Photo Library ({photos.length} photos)
           </h2>
-          <div className="flex rounded-lg border border-gray-200 overflow-hidden">
+          <div className="flex w-full flex-wrap items-stretch overflow-hidden rounded-lg border border-gray-200 sm:w-auto">
             <button
               onClick={() => setViewMode('grid')}
-              className={`px-4 py-2 text-sm transition-colors ${
+              className={`flex-1 px-4 py-2 text-sm font-medium transition-colors sm:flex-none ${
                 viewMode === 'grid'
                   ? 'bg-blue-600 text-white'
                   : 'bg-white text-gray-700 hover:bg-gray-50'
@@ -87,7 +87,7 @@ export default function PhotoGrid({ photos, onPhotoDeleted }: PhotoGridProps) {
             </button>
             <button
               onClick={() => setViewMode('duplicates')}
-              className={`px-4 py-2 text-sm transition-colors ${
+              className={`flex-1 px-4 py-2 text-sm font-medium transition-colors sm:flex-none ${
                 viewMode === 'duplicates'
                   ? 'bg-blue-600 text-white'
                   : 'bg-white text-gray-700 hover:bg-gray-50'
@@ -97,11 +97,11 @@ export default function PhotoGrid({ photos, onPhotoDeleted }: PhotoGridProps) {
             </button>
           </div>
         </div>
-        
+
         {selectedPhotos.size > 0 && (
           <button
             onClick={handleBatchDelete}
-            className="flex items-center gap-2 px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors"
+            className="flex w-full items-center justify-center gap-2 rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-700 sm:w-auto"
           >
             <Trash2 className="w-4 h-4" />
             Delete Selected ({selectedPhotos.size})
@@ -110,7 +110,7 @@ export default function PhotoGrid({ photos, onPhotoDeleted }: PhotoGridProps) {
       </div>
 
       {viewMode === 'grid' && (
-        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4">
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 sm:gap-4 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
           {photos.map((photo) => (
             <div
               key={photo.id}
@@ -184,21 +184,21 @@ export default function PhotoGrid({ photos, onPhotoDeleted }: PhotoGridProps) {
             </div>
           ) : (
             Object.entries(groupedPhotos).map(([group, groupPhotos]) => (
-              <div key={group} className="border rounded-lg p-4">
-                <div className="flex items-center justify-between mb-3">
+              <div key={group} className="rounded-lg border p-4 sm:p-5">
+                <div className="mb-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                   <h3 className="font-semibold text-gray-900 flex items-center gap-2">
                     <Copy className="w-5 h-5 text-orange-500" />
                     Duplicate Group ({groupPhotos.length} photos)
                   </h3>
                   <button
                     onClick={() => handleCompareGroup(groupPhotos)}
-                    className="flex items-center gap-2 px-3 py-1 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors text-sm"
+                    className="flex w-full items-center justify-center gap-2 rounded-lg bg-blue-600 px-3 py-1 text-sm font-medium text-white transition-colors hover:bg-blue-700 sm:w-auto"
                   >
                     <Eye className="w-4 h-4" />
                     Compare
                   </button>
                 </div>
-                <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
+                <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 sm:gap-4 md:grid-cols-4 lg:grid-cols-5">
                   {groupPhotos.map((photo) => (
                     <div
                       key={photo.id}

--- a/src/components/PhotoUploader.tsx
+++ b/src/components/PhotoUploader.tsx
@@ -123,7 +123,7 @@ export default function PhotoUploader({ onPhotosUploaded }: PhotoUploaderProps) 
   return (
     <div className="w-full max-w-2xl mx-auto">
       <div
-        className={`border-2 border-dashed rounded-lg p-8 text-center transition-colors cursor-pointer ${
+        className={`border-2 border-dashed rounded-lg p-6 text-center transition-colors cursor-pointer sm:p-8 ${
           isDragging
             ? 'border-blue-500 bg-blue-50'
             : 'border-gray-300 hover:border-gray-400'
@@ -148,10 +148,10 @@ export default function PhotoUploader({ onPhotosUploaded }: PhotoUploaderProps) 
           </div>
           
           <div>
-            <h3 className="text-lg font-semibold text-gray-900 mb-2">
+            <h3 className="mb-2 text-lg font-semibold text-gray-900">
               Upload Your Photos
             </h3>
-            <p className="text-gray-600 mb-4">
+            <p className="mb-4 text-sm text-gray-600 sm:text-base">
               Drag and drop your photos here, or click to select files
             </p>
             
@@ -170,8 +170,8 @@ export default function PhotoUploader({ onPhotosUploaded }: PhotoUploaderProps) 
             )}
           </div>
           
-          <div className="flex items-center gap-2">
-            <Upload className="w-5 h-5 text-gray-400" />
+          <div className="flex flex-col items-center gap-2 text-center sm:flex-row sm:text-left">
+            <Upload className="h-5 w-5 text-gray-400" />
             <span className="text-sm text-gray-500">
               Supports JPG, PNG, GIF, and other image formats
             </span>


### PR DESCRIPTION
## Summary
- update the landing layout and navigation buttons so they scale smoothly on small screens
- refine the photo grid controls and duplicate group actions to stack cleanly on mobile
- make the comparison modal scrollable with mobile-friendly actions and soften uploader spacing for handheld devices

## Testing
- npm run lint
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68ce51765804832e97b98336a0cda5f5