### PR TITLE
Sanitize photo metadata before duplicate analysis

### DIFF
--- a/src/hooks/usePhotoAnalysis.ts
+++ b/src/hooks/usePhotoAnalysis.ts
@@ -20,14 +20,21 @@ export function usePhotoAnalysis(photos: Photo[]) {
     setProgress(0)
     
     try {
+      const sanitizedPhotos = photos.map(photo => ({
+        ...photo,
+        isDuplicate: undefined,
+        group: undefined,
+        similarityScore: undefined,
+      }))
+
       // Step 1: Find exact duplicates (fast)
       setProgress(25)
-      const exactDuplicates = findDuplicates(photos)
+      const exactDuplicates = findDuplicates(sanitizedPhotos)
       setDuplicates(exactDuplicates)
-      
+
       // Step 2: Find similar photos using perceptual hashing (slower)
       setProgress(50)
-      const similarPhotos = await findSimilarPhotos(photos, 0.85)
+      const similarPhotos = await findSimilarPhotos(sanitizedPhotos, 0.85)
       setSimilar(similarPhotos)
       
       setProgress(100)


### PR DESCRIPTION
## Summary
- sanitize photo metadata before running duplicate and similarity analysis
- update duplicate and similar photo detection helpers to avoid mutating inputs while returning only the new duplicates

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7fd499f80832ea34d7578255ecb36