### PR TITLE
Fix duplicate grouping to include reference photos

### DIFF
--- a/src/components/PhotoGrid.tsx
+++ b/src/components/PhotoGrid.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useMemo } from 'react'
 import Image from 'next/image'
 import { Trash2, Eye, Copy, Check, Camera } from 'lucide-react'
 import { Photo } from '@/types'
@@ -43,7 +43,13 @@ export default function PhotoGrid({ photos, onPhotoDeleted }: PhotoGridProps) {
   }
 
   const handleCompareGroup = (groupPhotos: Photo[]) => {
-    setComparisonPhotos(groupPhotos)
+    const orderedPhotos = groupPhotos.slice().sort((a, b) => {
+      const aValue = a.isDuplicate ? 1 : 0
+      const bValue = b.isDuplicate ? 1 : 0
+      return aValue - bValue
+    })
+
+    setComparisonPhotos(orderedPhotos)
     setShowComparison(true)
   }
 
@@ -55,17 +61,31 @@ export default function PhotoGrid({ photos, onPhotoDeleted }: PhotoGridProps) {
     return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i]
   }
 
-  const duplicatePhotos = photos.filter(photo => photo.isDuplicate)
-  const uniquePhotos = photos.filter(photo => !photo.isDuplicate)
-  
-  const groupedPhotos = duplicatePhotos.reduce((acc, photo) => {
-    const group = photo.group || 'ungrouped'
-    if (!acc[group]) {
-      acc[group] = []
-    }
-    acc[group].push(photo)
-    return acc
-  }, {} as Record<string, Photo[]>)
+  const duplicateGroups = useMemo(() => {
+    const groups = photos.reduce<Record<string, Photo[]>>((acc, photo) => {
+      if (!photo.group) return acc
+
+      if (!acc[photo.group]) {
+        acc[photo.group] = []
+      }
+
+      acc[photo.group].push(photo)
+      return acc
+    }, {})
+
+    return Object.entries(groups)
+      .map(([groupId, groupPhotos]) => ({
+        id: groupId,
+        photos: groupPhotos
+          .slice()
+          .sort((a, b) => {
+            const aValue = a.isDuplicate ? 1 : 0
+            const bValue = b.isDuplicate ? 1 : 0
+            return aValue - bValue
+          }),
+      }))
+      .filter(group => group.photos.length > 1)
+  }, [photos])
 
   return (
     <div className="space-y-6">
@@ -176,15 +196,15 @@ export default function PhotoGrid({ photos, onPhotoDeleted }: PhotoGridProps) {
 
       {viewMode === 'duplicates' && (
         <div className="space-y-6">
-          {Object.keys(groupedPhotos).length === 0 ? (
+          {duplicateGroups.length === 0 ? (
             <div className="text-center py-12">
               <Camera className="w-16 h-16 mx-auto text-gray-400 mb-4" />
               <h3 className="text-lg font-medium text-gray-900 mb-2">No duplicates found</h3>
               <p className="text-gray-600">Upload more photos to detect duplicates</p>
             </div>
           ) : (
-            Object.entries(groupedPhotos).map(([group, groupPhotos]) => (
-              <div key={group} className="rounded-lg border p-4 sm:p-5">
+            duplicateGroups.map(({ id, photos: groupPhotos }) => (
+              <div key={id} className="rounded-lg border p-4 sm:p-5">
                 <div className="mb-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                   <h3 className="font-semibold text-gray-900 flex items-center gap-2">
                     <Copy className="w-5 h-5 text-orange-500" />

--- a/src/lib/imageHash.ts
+++ b/src/lib/imageHash.ts
@@ -131,10 +131,12 @@ export function findDuplicates(photos: Photo[]): Photo[] {
       // Mark all but the first as duplicates
       const groupId = `group-${Date.now()}-${Math.random()}`
       group.forEach((photo, index) => {
+        photo.group = groupId
         if (index > 0) {
           photo.isDuplicate = true
-          photo.group = groupId
           duplicates.push(photo)
+        } else {
+          photo.isDuplicate = false
         }
       })
     }
@@ -190,10 +192,12 @@ export async function findSimilarPhotos(photos: Photo[], threshold: number = 0.8
     if (group.length > 1) {
       const groupId = `similar-${Date.now()}-${Math.random()}`
       group.forEach((photo, index) => {
+        photo.group = groupId
         if (index > 0) {
           photo.isDuplicate = true
-          photo.group = groupId
           similar.push(photo)
+        } else {
+          photo.isDuplicate = false
         }
       })
     }


### PR DESCRIPTION
## Summary
- ensure the hashing utilities tag both the reference photo and its duplicates with a shared group id while leaving the lead asset marked as non-duplicate
- rebuild the duplicate tab grouping logic to derive comparison sets from the latest photos prop so reference images are shown alongside duplicates

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7fd55c2ec832eb93fc7a55651936c